### PR TITLE
Add support for Python 3.9

### DIFF
--- a/translitcodec/__init__.py
+++ b/translitcodec/__init__.py
@@ -82,8 +82,12 @@ def trans_search(encoding):
     # translit/one
     # translit/short/ascii
 
-    if encoding.startswith('translit/'):
-        parts = encoding.split('/')
+    delim = '/'
+    if sys.version_info > (3, 9):
+        delim = '_'
+
+    if encoding.startswith('translit' + delim):
+        parts = encoding.split(delim)
         if parts[1] == 'long':
             encoder = long_encode
         elif parts[1] == 'short':


### PR DESCRIPTION
In 3.9 codecs.lookup() started to normalize the encoding name, so there is a need to check for translit_type instead of translit/type. Otherwise `codecs.encode('str', 'translit/long')` fails with `LookupError: unknown encoding: translit/long`